### PR TITLE
  Upgrade analysis to MSP-first rfmix_reader workflow

### DIFF
--- a/rfmix_reader/__init__.py
+++ b/rfmix_reader/__init__.py
@@ -15,6 +15,7 @@ except PackageNotFoundError:
 __all__ = [
     "Chunk",
     "read_fb", "read_simu", "read_rfmix", "read_rfmix_fb", "read_flare",
+    "extract_locus_ancestry",
     "write_data",
     "admix_to_bed_individual",
     "CHROM_SIZES", "COORDINATES",
@@ -34,6 +35,7 @@ _lazy = {
     "read_fb": (".readers.fb_read", "read_fb"),
     "read_simu": (".readers.read_simu", "read_simu"),
     "read_rfmix": (".readers.read_msp", "read_rfmix"),
+    "extract_locus_ancestry": (".readers.read_msp", "extract_locus_ancestry"),
     "read_rfmix_fb": (".readers.read_rfmix", "read_rfmix_fb"),
     "read_flare": (".readers.read_flare", "read_flare"),
     "write_data": (".io.write_data", "write_data"),
@@ -84,7 +86,7 @@ if TYPE_CHECKING:
     from .processing.imputation import interpolate_array
     from .io.loci_bed import admix_to_bed_individual
     from .readers.read_flare import read_flare
-    from .readers.read_msp import read_rfmix
+    from .readers.read_msp import read_rfmix, extract_locus_ancestry
     from .readers.read_rfmix import read_rfmix_fb
     from .readers.read_simu import read_simu
     from .viz.tagore import plot_local_ancestry_tagore

--- a/rfmix_reader/readers/__init__.py
+++ b/rfmix_reader/readers/__init__.py
@@ -1,9 +1,37 @@
 """Reader utilities for RFMix and related formats."""
 
-from .fb_read import read_fb
-from .read_flare import read_flare
-from .read_msp import read_rfmix
-from .read_rfmix import read_rfmix_fb
-from .read_simu import read_simu
+from __future__ import annotations
 
-__all__ = ["read_fb", "read_flare", "read_rfmix", "read_rfmix_fb", "read_simu"]
+__all__ = [
+    "read_fb",
+    "read_flare",
+    "read_rfmix",
+    "read_rfmix_fb",
+    "read_simu",
+    "extract_locus_ancestry",
+]
+
+_lazy = {
+    "read_fb": (".fb_read", "read_fb"),
+    "read_flare": (".read_flare", "read_flare"),
+    "read_rfmix": (".read_msp", "read_rfmix"),
+    "extract_locus_ancestry": (".read_msp", "extract_locus_ancestry"),
+    "read_rfmix_fb": (".read_rfmix", "read_rfmix_fb"),
+    "read_simu": (".read_simu", "read_simu"),
+}
+
+
+def __getattr__(name: str):
+    if name in _lazy:
+        import importlib
+
+        mod_name, attr_name = _lazy[name]
+        mod = importlib.import_module(mod_name, __name__)
+        obj = getattr(mod, attr_name)
+        globals()[name] = obj
+        return obj
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/rfmix_reader/readers/read_msp.py
+++ b/rfmix_reader/readers/read_msp.py
@@ -17,15 +17,17 @@ Values are integer ancestry codes (0 = first listed population, 1 = second, …)
 """
 from __future__ import annotations
 
+import gzip
 import re
 import numpy as np
 import pandas as pd
 import dask.array as da
 from tqdm import tqdm
 from pathlib import Path
-from typing import Optional, Tuple, List, Dict
+from typing import Optional, Tuple, List, Dict, Sequence
 
 from ..utils import (
+    _extract_chrom_from_path,
     _read_file,
     filter_file_maps_by_chrom,
     set_gpu_environment,
@@ -43,9 +45,10 @@ else:
     from pandas import DataFrame, concat, CategoricalDtype
 
 
-__all__ = ["read_rfmix"]
+__all__ = ["read_rfmix", "extract_locus_ancestry"]
 
 _MSP_SUFFIXES = ["msp.tsv", "msp.tsv.gz"]
+_Q_SUFFIXES = ["rfmix.Q", "rfmix.Q.gz"]
 _META_COLS = ["#chm", "spos", "epos", "sgpos", "egpos", "n snps"]
 
 
@@ -58,7 +61,7 @@ def _parse_pop_header(fn: str) -> Dict[str, int]:
 
     Returns a dict mapping population label → integer code, e.g. {"AFR": 0, "EUR": 1}.
     """
-    opener = __import__("gzip").open if fn.endswith(".gz") else open
+    opener = gzip.open if fn.endswith(".gz") else open
     with opener(fn, "rt") as fh:
         line = fh.readline().strip()
     pairs = re.findall(r"(\w+)=(\d+)", line)
@@ -102,6 +105,19 @@ def _read_msp_file(fn: str) -> Tuple[DataFrame, List[str], Dict[str, int]]:
     return segs, hap_cols, pop_map
 
 
+def _sample_names_from_hap_cols(hap_cols: Sequence[str]) -> List[str]:
+    samples = []
+    for i in range(0, len(hap_cols), 2):
+        h0 = hap_cols[i]
+        h1 = hap_cols[i + 1]
+        sample0 = h0.rsplit(".", 1)[0]
+        sample1 = h1.rsplit(".", 1)[0]
+        if sample0 != sample1:
+            raise ValueError(f"Haplotype columns are not paired: {h0}, {h1}")
+        samples.append(sample0)
+    return samples
+
+
 def _segments_to_loci(
     segs: pd.DataFrame,
     hap_cols: List[str],
@@ -135,13 +151,11 @@ def _segments_to_loci(
         Shape (n_segments, n_samples, n_ancestries), dtype int32.
     """
     n_pops = len(pop_map)
-    # Infer samples from hap_cols: Sample_1.0, Sample_1.1, Sample_2.0, …
-    # Pair adjacent columns as (hap0, hap1) per sample
     if len(hap_cols) % 2 != 0:
         raise ValueError(
             f"Expected an even number of haplotype columns, got {len(hap_cols)}."
         )
-    n_samples = len(hap_cols) // 2
+    n_samples = len(_sample_names_from_hap_cols(hap_cols))
     n_segs = len(segs)
 
     # Build the ancestry count array: shape (n_segs, n_samples, n_pops)
@@ -207,6 +221,11 @@ def _get_msp_prefixes(file_prefix: str, verbose: bool = True) -> List[Dict[str, 
                 key = sfx.replace(".gz", "")
                 filemap[key] = candidate
                 break  # prefer plain over .gz
+        for sfx in _Q_SUFFIXES:
+            candidate = f"{pfx}.{sfx}"
+            if Path(candidate).exists():
+                filemap["rfmix.Q"] = candidate
+                break
         if filemap:
             fn.append(filemap)
 
@@ -222,21 +241,201 @@ def _get_msp_prefixes(file_prefix: str, verbose: bool = True) -> List[Dict[str, 
     return fn
 
 
-def _read_Q_for_msp(fn: str, pop_map: Dict[str, int]) -> DataFrame:
-    """
-    Build a minimal global-ancestry DataFrame from the MSP segment data.
 
-    RFMix .rfmix.Q files are not required when reading .msp.tsv.  Instead,
-    we compute per-sample global ancestry proportions by weighting each
-    segment by its physical length.
-
-    Returns a DataFrame with columns [sample_id, <pop1>, <pop2>, …, chrom].
+def _read_Q_for_msp(fn: str) -> DataFrame:
     """
-    raise NotImplementedError(
-        "Global ancestry from .msp.tsv is not yet implemented. "
-        "Pass a pre-loaded g_anc DataFrame or read it separately with "
-        "read_rfmix_fb() and reuse its g_anc."
+    Read an RFMix ``.rfmix.Q`` file next to MSP output.
+
+    Returns a DataFrame with columns ``sample_id``, one column per ancestry,
+    and ``chrom`` when the chromosome label can be inferred from the file name.
+    """
+    opener = gzip.open if fn.endswith(".gz") else open
+    with opener(fn, "rt") as fh:
+        fh.readline()
+        header_line = fh.readline().strip()
+    if not header_line.startswith("#"):
+        raise ValueError(
+            f"Could not parse Q header from '{fn}'. Expected second line to start with '#'."
+        )
+    header = header_line.lstrip("#").split()
+    if not header or header[0] != "sample":
+        raise ValueError(f"Could not parse sample column from Q header in '{fn}'.")
+
+    df = pd.read_csv(
+        fn,
+        sep=r"\s+",
+        comment="#",
+        header=None,
+        names=["sample_id", *header[1:]],
+        compression="infer",
     )
+    chrom_label = _extract_chrom_from_path(fn)
+    if chrom_label is not None:
+        df["chrom"] = f"chr{chrom_label}"
+    return df
+
+
+def _norm_chrom(value: object) -> str:
+    text = str(value).strip()
+    if text.lower().startswith("chr"):
+        text = text[3:]
+    return text
+
+
+def extract_locus_ancestry(
+    file_prefix: str,
+    loci: pd.DataFrame,
+    chrom_col: str = "chrom",
+    pos_col: str = "pos",
+    samples: Optional[Sequence[str]] = None,
+    aggregate: bool = True,
+) -> pd.DataFrame:
+    """
+    Query MSP hard-call local ancestry at selected SNP positions.
+
+    This function scans MSP interval rows and returns ancestry at the requested
+    loci without expanding the full genome into a dense variant-by-sample matrix.
+    Intervals are treated as closed on both sides: ``spos <= pos <= epos``.
+    """
+    if chrom_col not in loci.columns or pos_col not in loci.columns:
+        raise ValueError(
+            f"loci must contain '{chrom_col}' and '{pos_col}' columns."
+        )
+    if loci.empty:
+        return loci.copy()
+
+    loci_work = loci.reset_index(drop=False).rename(columns={"index": "_locus_index"})
+    loci_work["_chrom_norm"] = loci_work[chrom_col].map(_norm_chrom)
+    loci_work["_pos_int"] = pd.to_numeric(loci_work[pos_col], errors="raise").astype(np.int64)
+    target_chroms = set(loci_work["_chrom_norm"].astype(str))
+
+    rows: List[dict] = []
+    seen_loci = set()
+    first_pop_labels: List[str] = []
+    first_sample_count: Optional[int] = None
+
+    for filemap in _get_msp_prefixes(file_prefix, verbose=False):
+        segs, hap_cols, pop_map = _read_msp_file(filemap["msp.tsv"])
+        segs_pd = segs.to_pandas() if hasattr(segs, "to_pandas") else segs
+        seg_chroms = segs_pd["chrom"].map(_norm_chrom)
+        common_chroms = sorted(target_chroms.intersection(set(seg_chroms.astype(str))))
+        if not common_chroms:
+            continue
+
+        sample_names = _sample_names_from_hap_cols(hap_cols)
+        pop_labels = [pop for pop, _ in sorted(pop_map.items(), key=lambda item: item[1])]
+        if not first_pop_labels:
+            first_pop_labels = pop_labels
+        if samples is None:
+            sample_idx = list(range(len(sample_names)))
+            selected_samples = sample_names
+        else:
+            missing = [sample for sample in samples if sample not in sample_names]
+            if missing:
+                raise ValueError(f"Samples not found in MSP file: {missing}")
+            sample_idx = [sample_names.index(sample) for sample in samples]
+            selected_samples = list(samples)
+        if first_sample_count is None:
+            first_sample_count = len(selected_samples)
+
+        n_pops = len(pop_labels)
+        selected_hap_cols = []
+        for sample_i in sample_idx:
+            selected_hap_cols.extend(hap_cols[(2 * sample_i):(2 * sample_i + 2)])
+
+        for chrom in common_chroms:
+            seg_chr = segs_pd.loc[seg_chroms == chrom].sort_values("spos")
+            target_chr = loci_work.loc[loci_work["_chrom_norm"] == chrom].copy()
+            starts = seg_chr["spos"].to_numpy(dtype=np.int64)
+            ends = seg_chr["epos"].to_numpy(dtype=np.int64)
+            positions = target_chr["_pos_int"].to_numpy(dtype=np.int64)
+            seg_idx = np.searchsorted(starts, positions, side="right") - 1
+            safe_idx = np.clip(seg_idx, 0, max(len(seg_chr) - 1, 0))
+            in_bounds = (
+                (seg_idx >= 0)
+                & (seg_idx < len(seg_chr))
+                & (positions <= ends[safe_idx])
+            )
+            seg_chr_reset = seg_chr.reset_index(drop=True)
+
+            for target_row, idx, matched in zip(target_chr.to_dict("records"), seg_idx, in_bounds):
+                base = {
+                    k: v for k, v in target_row.items()
+                    if k not in {"_chrom_norm", "_pos_int"}
+                }
+                base["matched"] = bool(matched)
+                seen_loci.add(base["_locus_index"])
+                if not matched:
+                    if aggregate:
+                        base["n_samples"] = len(selected_samples)
+                        base["n_haplotypes"] = 0
+                        for pop in pop_labels:
+                            base[f"{pop}_haplotypes"] = np.nan
+                            base[f"{pop}_fraction"] = np.nan
+                        rows.append(base)
+                    else:
+                        for sample in selected_samples:
+                            sample_row = dict(base)
+                            sample_row["sample_id"] = sample
+                            for pop in pop_labels:
+                                sample_row[f"{pop}_copies"] = np.nan
+                            rows.append(sample_row)
+                    continue
+
+                calls = seg_chr_reset.loc[int(idx), selected_hap_cols].to_numpy(dtype=np.int16)
+                calls = calls.reshape(len(selected_samples), 2)
+                if aggregate:
+                    flat = calls.reshape(-1)
+                    counts = np.bincount(flat, minlength=n_pops)
+                    total = int(counts.sum())
+                    base["n_samples"] = len(selected_samples)
+                    base["n_haplotypes"] = total
+                    for pop, count in zip(pop_labels, counts):
+                        base[f"{pop}_haplotypes"] = int(count)
+                        base[f"{pop}_fraction"] = float(count / total) if total else np.nan
+                    rows.append(base)
+                else:
+                    for sample, sample_calls in zip(selected_samples, calls):
+                        sample_row = dict(base)
+                        sample_row["sample_id"] = sample
+                        sample_counts = np.bincount(sample_calls, minlength=n_pops)
+                        for pop, count in zip(pop_labels, sample_counts):
+                            sample_row[f"{pop}_copies"] = int(count)
+                        rows.append(sample_row)
+
+    missing_loci = loci_work.loc[~loci_work["_locus_index"].isin(seen_loci)]
+    for target_row in missing_loci.to_dict("records"):
+        base = {
+            k: v for k, v in target_row.items()
+            if k not in {"_chrom_norm", "_pos_int"}
+        }
+        base["matched"] = False
+        if aggregate:
+            base["n_samples"] = first_sample_count if first_sample_count is not None else np.nan
+            base["n_haplotypes"] = 0
+            for pop in first_pop_labels:
+                base[f"{pop}_haplotypes"] = np.nan
+                base[f"{pop}_fraction"] = np.nan
+            rows.append(base)
+        else:
+            selected_samples = list(samples) if samples is not None else []
+            if not selected_samples:
+                rows.append(base)
+            for sample in selected_samples:
+                sample_row = dict(base)
+                sample_row["sample_id"] = sample
+                for pop in first_pop_labels:
+                    sample_row[f"{pop}_copies"] = np.nan
+                rows.append(sample_row)
+
+    result = pd.DataFrame(rows)
+    if "_locus_index" in result.columns:
+        sort_cols = ["_locus_index"]
+        if "sample_id" in result.columns:
+            sort_cols.append("sample_id")
+        result = result.sort_values(sort_cols).reset_index(drop=True)
+        result = result.drop(columns=["_locus_index"])
+    return result
 
 
 def read_rfmix(
@@ -244,6 +443,7 @@ def read_rfmix(
     g_anc: Optional[DataFrame] = None,
     verbose: bool = True,
     chrom: Optional[str] = None,
+    read_q: bool = True,
 ) -> Tuple[DataFrame, Optional[DataFrame], da.Array]:
     """
     Read RFMix `.msp.tsv` files into a loci DataFrame and a Dask ancestry array.
@@ -270,6 +470,9 @@ def read_rfmix(
         Print progress information.
     chrom : str, optional
         Restrict reading to a single chromosome (with or without ``chr`` prefix).
+    read_q : bool, default True
+        When ``g_anc`` is not supplied, read neighboring ``.rfmix.Q`` files when
+        present and return their concatenated global ancestry table.
 
     Returns
     -------
@@ -310,6 +513,14 @@ def read_rfmix(
     results = _read_file(fn, lambda f: _read_msp_file(f["msp.tsv"]), pbar)
     pbar.close()
 
+    if g_anc is None and read_q:
+        q_maps = [f for f in fn if "rfmix.Q" in f]
+        if q_maps:
+            pbar = tqdm(desc="Reading Q files", total=len(q_maps), disable=not verbose)
+            q_dfs = _read_file(q_maps, lambda f: _read_Q_for_msp(f["rfmix.Q"]), pbar)
+            pbar.close()
+            g_anc = concat(q_dfs, axis=0, ignore_index=True)
+
     index_offset = 0
     loci_dfs = []
     local_arrays = []
@@ -333,3 +544,4 @@ def read_rfmix(
 read_rfmix._parse_pop_header = _parse_pop_header
 read_rfmix._read_msp_file = _read_msp_file
 read_rfmix._segments_to_loci = _segments_to_loci
+read_rfmix.extract_locus_ancestry = extract_locus_ancestry

--- a/tests/test_read_msp.py
+++ b/tests/test_read_msp.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the read_rfmix reader (reads .msp.tsv files).
 """
+import gzip
 import pytest
 import importlib
 
@@ -13,6 +14,7 @@ _parse_pop_header = msp_mod._parse_pop_header
 _read_msp_file = msp_mod._read_msp_file
 _segments_to_loci = msp_mod._segments_to_loci
 _get_msp_prefixes = msp_mod._get_msp_prefixes
+extract_locus_ancestry = msp_mod.extract_locus_ancestry
 read_rfmix = msp_mod.read_rfmix
 
 _MSP_CONTENT = """\
@@ -145,3 +147,75 @@ def test_get_msp_prefixes_accepts_path_prefix(tmp_path):
     result = _get_msp_prefixes(str(tmp_path / "run_chr1"), verbose=False)
 
     assert result == [{"msp.tsv": str(fn)}]
+
+
+_Q_CONTENT = """\
+#rfmix diploid global ancestry .Q format output
+#sample	AFR	EUR
+Sample_1	0.5	0.5
+Sample_2	0.25	0.75
+"""
+
+
+def test_get_msp_prefixes_accepts_gzip(tmp_path):
+    fn = tmp_path / "chr1.msp.tsv.gz"
+    with gzip.open(fn, "wt") as fh:
+        fh.write(_MSP_CONTENT)
+
+    result = _get_msp_prefixes(str(tmp_path), verbose=False)
+
+    assert result == [{"msp.tsv": str(fn)}]
+
+
+def test_read_rfmix_reads_neighboring_q(tmp_path):
+    (tmp_path / "chr1.msp.tsv").write_text(_MSP_CONTENT)
+    (tmp_path / "chr1.rfmix.Q").write_text(_Q_CONTENT)
+
+    _, g_anc_out, _ = read_rfmix(str(tmp_path), verbose=False)
+
+    assert g_anc_out is not None
+    assert list(g_anc_out.columns) == ["sample_id", "AFR", "EUR", "chrom"]
+    assert list(g_anc_out["sample_id"]) == ["Sample_1", "Sample_2"]
+    assert list(g_anc_out["chrom"]) == ["chr1", "chr1"]
+
+
+def test_read_rfmix_can_skip_q(tmp_path):
+    (tmp_path / "chr1.msp.tsv").write_text(_MSP_CONTENT)
+    (tmp_path / "chr1.rfmix.Q").write_text(_Q_CONTENT)
+
+    _, g_anc_out, _ = read_rfmix(str(tmp_path), verbose=False, read_q=False)
+
+    assert g_anc_out is None
+
+
+def test_extract_locus_ancestry_aggregate_boundary_and_outside(tmp_path):
+    (tmp_path / "chr1.msp.tsv").write_text(_MSP_CONTENT)
+    loci = pd.DataFrame({
+        "variant_id": ["inside", "boundary", "outside"],
+        "chrom": ["1", "chr1", "chr1"],
+        "pos": [10001, 50000, 90001],
+    })
+
+    out = extract_locus_ancestry(str(tmp_path), loci, aggregate=True)
+
+    assert list(out["variant_id"]) == ["inside", "boundary", "outside"]
+    assert list(out["matched"]) == [True, True, False]
+    assert out.loc[0, "AFR_haplotypes"] == 1
+    assert out.loc[0, "EUR_haplotypes"] == 3
+    assert out.loc[1, "AFR_haplotypes"] == 1
+    assert out.loc[1, "EUR_fraction"] == 0.75
+    assert pd.isna(out.loc[2, "AFR_fraction"])
+
+
+def test_extract_locus_ancestry_sample_level_subset(tmp_path):
+    (tmp_path / "chr1.msp.tsv").write_text(_MSP_CONTENT)
+    loci = pd.DataFrame({"chrom": ["chr1"], "pos": [50001], "rsid": ["rs1"]})
+
+    out = extract_locus_ancestry(
+        str(tmp_path), loci, samples=["Sample_2"], aggregate=False
+    )
+
+    assert out.shape[0] == 1
+    assert out.loc[0, "sample_id"] == "Sample_2"
+    assert out.loc[0, "AFR_copies"] == 1
+    assert out.loc[0, "EUR_copies"] == 1


### PR DESCRIPTION
  - Add MSP read_q support and targeted extract_locus_ancestry API
  - Export MSP APIs and keep dense .fb reader as read_rfmix_fb
  - Add MSP reader tests for gzip discovery, Q loading, and SNP interval queries
  - Update legacy dense .fb analysis scripts to call read_rfmix_fb explicitly
  - Add CPU-only MSP benchmark for read and targeted SNP query operations
  - Extend benchmark metadata with input_format and operation labels
  - Add AD SNP-level MSP local ancestry workflow and curated GRCh38 gene windows
  - Add CPU conda environment and README instructions for Bridges-2 workflows